### PR TITLE
Add optional support for using brzo as i2c lib

### DIFF
--- a/SSD1306.h
+++ b/SSD1306.h
@@ -28,9 +28,21 @@
 #pragma once
 
 #include <Arduino.h>
-#include <Wire.h>
-
 #include "SSD1306Fonts.h"
+
+#ifdef SSD1306_USE_BRZO
+  #include "brzo_i2c.h"
+  // Brzo can handle 1Mhz in ESP8266 160Mhz mode
+  // and 800KHz in 80Mhz mode
+  #if F_CPU == 160000000L
+    #define BRZO_I2C_SPEED 1000
+  #else
+    #define BRZO_I2C_SPEED 800
+  #endif
+#else // Default use Wire
+  #include <Wire.h>
+#endif
+
 
 //#define DEBUG_SSD1306(...) Serial.printf( __VA_ARGS__ )
 


### PR DESCRIPTION
See https://github.com/pasko-zh/brzo_i2c for more info about the
library. It is very fast and can run the OLED at 120fps even in 80Mhz
mode.

To use the library use have to add the library in your build path and add the flag `SSD1306_USE_BRZO` to the build. Using platformio adding this `build_flags = -DSSD1306_USE_BRZO` to your platformio.ini will work 