### PR TITLE
Reset state values when calling setFrames

### DIFF
--- a/OLEDDisplayUi.cpp
+++ b/OLEDDisplayUi.cpp
@@ -95,22 +95,20 @@ void OLEDDisplayUi::setFrameAnimation(AnimationDirection dir) {
   this->frameAnimationDirection = dir;
 }
 void OLEDDisplayUi::setFrames(FrameCallback* frameFunctions, uint8_t frameCount) {
-  this->frameCount     = frameCount;
   this->frameFunctions = frameFunctions;
+  this->frameCount     = frameCount;
+  this->resetState();
 }
 
 // -/----- Overlays ------\-
 void OLEDDisplayUi::setOverlays(OverlayCallback* overlayFunctions, uint8_t overlayCount){
-  this->overlayCount     = overlayCount;
   this->overlayFunctions = overlayFunctions;
+  this->overlayCount     = overlayCount;
 }
 
 // -/----- Loading Process -----\-
 
 void OLEDDisplayUi::runLoadingProcess(LoadingStage* stages, uint8_t stagesCount) {
-  display->setTextAlignment(TEXT_ALIGN_CENTER);
-  display->setFont(ArialMT_Plain_10);
-
   uint8_t progress = 0;
   uint8_t increment = 100 / stagesCount;
 
@@ -204,6 +202,14 @@ void OLEDDisplayUi::tick() {
   this->drawIndicator();
   this->drawOverlays();
   this->display->display();
+}
+
+void OLEDDisplayUi::resetState() {
+  this->state.lastUpdate = 0;
+  this->state.ticksSinceLastStateSwitch = 0;
+  this->state.frameState = FIXED;
+  this->state.currentFrame = 0;
+  this->state.isIndicatorDrawen = true;
 }
 
 void OLEDDisplayUi::drawFrame(){

--- a/OLEDDisplayUi.h
+++ b/OLEDDisplayUi.h
@@ -135,7 +135,9 @@ class OLEDDisplayUi {
 
     // Loading screen
     LoadingDrawFunction loadingDrawFunction       = [](OLEDDisplay *display, LoadingStage* stage, uint8_t progress) {
-      display->drawString(64, 20, stage->process);
+      display->setTextAlignment(TEXT_ALIGN_CENTER);
+      display->setFont(ArialMT_Plain_10);
+      display->drawString(64, 18, stage->process);
       display->drawProgressBar(4, 32, 120, 8, progress);
     };
 
@@ -150,6 +152,7 @@ class OLEDDisplayUi {
     void                drawFrame();
     void                drawOverlays();
     void                tick();
+    void                resetState();
 
   public:
 
@@ -255,7 +258,7 @@ class OLEDDisplayUi {
      * Set the function that will draw each step
      * in the loading animation
      */
-    void setLoadingDrawFunction(LoadingDrawFunction stage);
+    void setLoadingDrawFunction(LoadingDrawFunction loadingFunction);
 
 
     /**


### PR DESCRIPTION
Ensure that possible dangerous state value are reset when modifying the frames during runtime.