### PR TITLE
Fix detection of non drawable characters

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -362,7 +362,7 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, char* text, u
       byte currentCharWidth = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_WIDTH); // Width
 
       // Test if the char is drawable
-      if (msbJumpToChar != 255 && lsbJumpToChar != 255) {
+      if (!(msbJumpToChar == 255 && lsbJumpToChar == 255)) {
         // Get the position of the char data
         uint16_t charDataPosition = JUMPTABLE_START + sizeOfJumpTable + ((msbJumpToChar << 8) + lsbJumpToChar);
         drawInternal(xPos, yPos, currentCharWidth, textHeight, fontData, charDataPosition, charByteSize);


### PR DESCRIPTION
The logic of detecting a non drawable character was wrong. Only if both the `msb` and the `lsb` are 0xFF (255) we can ignore it.  