### PR TITLE
Calculating `strWidth` in drawStringMaxWidth correctly

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -427,11 +427,17 @@ void OLEDDisplay::drawStringMaxWidth(int16_t xMove, int16_t yMove, uint16_t maxL
     }
 
     if (strWidth >= maxLineWidth) {
-      preferredBreakpoint = preferredBreakpoint ? preferredBreakpoint : i;
-      widthAtBreakpoint = preferredBreakpoint ? widthAtBreakpoint : strWidth;
-
+      if (preferredBreakpoint == 0) {
+        preferredBreakpoint = i;
+        widthAtBreakpoint = strWidth;
+      }
       drawStringInternal(xMove, yMove + (lineNumber++) * lineHeight , &text[lastDrawnPos], preferredBreakpoint - lastDrawnPos, widthAtBreakpoint);
-      lastDrawnPos = preferredBreakpoint + 1; strWidth = 0; preferredBreakpoint = 0;
+      lastDrawnPos = preferredBreakpoint + 1;
+      // It is possible that we did not draw all letters to i so we need
+      // to account for the width of the chars from `i - preferredBreakpoint`
+      // by calculating the width we did not draw yet.
+      strWidth = strWidth - widthAtBreakpoint;
+      preferredBreakpoint = 0;
     }
   }
 


### PR DESCRIPTION
We had a bug in the calculation of the `strWidth` by always assuming it would be `0` after drawing. But that is not the case because we prefer to break on `[space]` or `-` thus we have to calculate the strWidth to be the width of the chars not drawn.  