### PR TITLE
Fix calculation of final drawBit in drawVerticalLine

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -278,7 +278,7 @@ void OLEDDisplay::drawVerticalLine(int16_t x, int16_t y, int16_t length) {
   }
 
   if (length > 0) {
-    drawBit = (1 << length & 7) - 1;
+    drawBit = (1 << (length & 7)) - 1;
     switch (color) {
       case WHITE:   *bufferPtr |= drawBit; break;
       case BLACK:   *bufferPtr &= drawBit; break;


### PR DESCRIPTION
Bitwise "and" has lower precedence than shift, so calculation of `drawBit` was not working the way it was intended, resulting in the following output (left). Correct output is on the right.
![image](https://cloud.githubusercontent.com/assets/4349050/16712106/1867ebb2-46ae-11e6-8087-c17121a5eddb.jpg)

Test case:
```c++
  display.clear();
  int x = 4;
  const int y0 = 16;
  for (int length = 1; length <= 32; ++length) {
    display.drawVerticalLine(x, y0, length);
    ++x;
  }
  display.display();
```