### PR TITLE
Improving rect drawing 

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -130,8 +130,8 @@ void OLEDDisplay::drawRect(int16_t x, int16_t y, int16_t width, int16_t height) 
 }
 
 void OLEDDisplay::fillRect(int16_t xMove, int16_t yMove, int16_t width, int16_t height) {
-  for (int16_t i = yMove; i < yMove + height; i++) {
-    drawHorizontalLine(xMove, i, width);
+  for (int16_t x = xMove; x < xMove + width; x++) {
+    drawVerticalLine(x, yMove, height);
   }
 }
 

--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -125,8 +125,8 @@ void OLEDDisplay::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1) {
 void OLEDDisplay::drawRect(int16_t x, int16_t y, int16_t width, int16_t height) {
   drawHorizontalLine(x, y, width);
   drawVerticalLine(x, y, height);
-  drawVerticalLine(x + width, y, height);
-  drawHorizontalLine(x, y + height, width);
+  drawVerticalLine(x + width - 1, y, height);
+  drawHorizontalLine(x, y + height - 1, width);
 }
 
 void OLEDDisplay::fillRect(int16_t xMove, int16_t yMove, int16_t width, int16_t height) {

--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -255,7 +255,7 @@ void OLEDDisplay::drawHorizontalLine(int16_t x, int16_t y, int16_t length) {
 }
 
 void OLEDDisplay::drawVerticalLine(int16_t x, int16_t y, int16_t length) {
-  if (x < 0 || x > DISPLAY_WIDTH) return;
+  if (x < 0 || x >= DISPLAY_WIDTH) return;
 
   if (y < 0) {
     length += y;
@@ -285,9 +285,9 @@ void OLEDDisplay::drawVerticalLine(int16_t x, int16_t y, int16_t length) {
     }
 
     switch (color) {
-      case WHITE:   *bufferPtr |= drawBit; break;
-      case BLACK:   *bufferPtr &= drawBit; break;
-      case INVERSE: *bufferPtr ^= drawBit; break;
+      case WHITE:   *bufferPtr |=  drawBit; break;
+      case BLACK:   *bufferPtr &= ~drawBit; break;
+      case INVERSE: *bufferPtr ^=  drawBit; break;
     }
 
     if (length < yOffset) return;
@@ -320,9 +320,9 @@ void OLEDDisplay::drawVerticalLine(int16_t x, int16_t y, int16_t length) {
   if (length > 0) {
     drawBit = (1 << (length & 7)) - 1;
     switch (color) {
-      case WHITE:   *bufferPtr |= drawBit; break;
-      case BLACK:   *bufferPtr &= drawBit; break;
-      case INVERSE: *bufferPtr ^= drawBit; break;
+      case WHITE:   *bufferPtr |=  drawBit; break;
+      case BLACK:   *bufferPtr &= ~drawBit; break;
+      case INVERSE: *bufferPtr ^=  drawBit; break;
     }
   }
 }

--- a/OLEDDisplay.h
+++ b/OLEDDisplay.h
@@ -138,6 +138,9 @@ class OLEDDisplay : public Print {
     // Draw the border of a circle
     void drawCircle(int16_t x, int16_t y, int16_t radius);
 
+    // Draw all Quadrants specified in the quads bit mask
+    void drawCircleQuads(int16_t x0, int16_t y0, int16_t radius, uint8_t quads);
+
     // Fill circle
     void fillCircle(int16_t x, int16_t y, int16_t radius);
 


### PR DESCRIPTION
This PR is changing the behaviour of `drawRect` as noted in #66. This is a taught issue because the API isn't effected by this but the behaviour is completely changed. According to semver this means we would have to release this in 4.0.0. 
`fillRect` is now implemented using `drawVerticalLine` to improve performance.

I also optimised the `drawProgressBar` function using the newly added `drawCircleQuads` function which allows for drawing 90° parts of a circle by using a bitmask to specify which quadrant of the circle should be drawn.
    