### PR TITLE
Add SH1106Spi support

### DIFF
--- a/SH1106Spi.h
+++ b/SH1106Spi.h
@@ -1,0 +1,128 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 by Daniel Eichhorn
+ * Copyright (c) 2016 by Fabrice Weinberg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Credits for parts of this code go to Mike Rankin. Thank you so much for sharing!
+ */
+
+#ifndef SH1106Spi_h
+#define SH1106Spi_h
+
+#include "OLEDDisplay.h"
+#include <SPI.h>
+
+class SH1106Spi : public OLEDDisplay {
+  private:
+      uint8_t             _rst;
+      uint8_t             _dc;
+
+  public:
+
+    SH1106Spi(uint8_t _rst, uint8_t _dc) {
+      this->_rst = _rst;
+      this->_dc  = _dc;
+    }
+
+    bool connect(){
+      pinMode(_dc, OUTPUT);
+      pinMode(_rst, OUTPUT);
+
+      SPI.begin ();
+      SPI.setClockDivider (SPI_CLOCK_DIV2);
+
+      // Pulse Reset low for 10ms
+      digitalWrite(_rst, HIGH);
+      delay(1);
+      digitalWrite(_rst, LOW);
+      delay(10);
+      digitalWrite(_rst, HIGH);
+      return true;
+    }
+
+    void display(void) {
+    #ifdef OLEDDISPLAY_DOUBLE_BUFFER
+       uint8_t minBoundY = ~0;
+       uint8_t maxBoundY = 0;
+
+       uint8_t minBoundX = ~0;
+       uint8_t maxBoundX = 0;
+
+       uint8_t x, y;
+
+       // Calculate the Y bounding box of changes
+       // and copy buffer[pos] to buffer_back[pos];
+       for (y = 0; y < (DISPLAY_HEIGHT / 8); y++) {
+         for (x = 0; x < DISPLAY_WIDTH; x++) {
+          uint16_t pos = x + y * DISPLAY_WIDTH;
+          if (buffer[pos] != buffer_back[pos]) {
+            minBoundY = _min(minBoundY, y);
+            maxBoundY = _max(maxBoundY, y);
+            minBoundX = _min(minBoundX, x);
+            maxBoundX = _max(maxBoundX, x);
+          }
+          buffer_back[pos] = buffer[pos];
+        }
+        yield();
+       }
+
+       // If the minBoundY wasn't updated
+       // we can savely assume that buffer_back[pos] == buffer[pos]
+       // holdes true for all values of pos
+       if (minBoundY == ~0) return;
+
+       // Calculate the colum offset
+       uint8_t minBoundXp2H = (minBoundX + 2) & 0x0F;
+       uint8_t minBoundXp2L = 0x10 | ((minBoundX + 2) >> 4 );
+
+       for (y = minBoundY; y <= maxBoundY; y++) {
+         sendCommand(0xB0 + y);
+         sendCommand(minBoundXp2H);
+         sendCommand(minBoundXp2L);
+         digitalWrite(_dc, HIGH);   // data mode
+         for (x = minBoundX; x <= maxBoundX; x++) {
+           SPI.transfer(buffer[x + y * DISPLAY_WIDTH]);
+         }
+         yield();
+       }
+     #else
+      for (uint8_t y=0; y<DISPLAY_HEIGHT/8; y++) {
+        sendCommand(0xB0 + y);
+        sendCommand(0x02);
+        sendCommand(0x10);
+        digitalWrite(_dc, HIGH);   // data mode
+        for( uint8_t x=0; x < DISPLAY_WIDTH; x++) {
+          SPI.transfer(buffer[x + y * DISPLAY_WIDTH]);
+        }
+        yield();
+      }
+     #endif
+    }
+
+  private:
+    inline void sendCommand(uint8_t com) __attribute__((always_inline)){
+      digitalWrite(_dc, LOW);
+      SPI.transfer(com);
+    }
+};
+
+#endif

--- a/examples/SSD1306ClockDemo/SSD1306ClockDemo.ino
+++ b/examples/SSD1306ClockDemo/SSD1306ClockDemo.ino
@@ -24,19 +24,21 @@
  *
  */
 
-#include <Wire.h>
 #include <TimeLib.h>
 
 // Include the correct display library
 // For a connection via I2C using Wire include
 #include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
 #include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
+// or #include "SH1106.h" alis for `#include "SH1106Wire.h"`
 // For a connection via I2C using brzo_i2c (must be installed) include
 // #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Brzo.h"
+// #include "SH1106Brzo.h"
 // For a connection via SPI include
 // #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Spi.h"
+// #include "SH1106SPi.h"
 
 // Include the UI lib
 #include "OLEDDisplayUi.h"
@@ -53,14 +55,19 @@
 // D2 -> DC
 // D8 -> CS
 // SSD1306Spi        display(D0, D2, D8);
+// or
+// SH1106Spi         display(D0, D2);
 
 // Initialize the OLED display using brzo_i2c
 // D3 -> SDA
-// D4 -> SCL
+// D5 -> SCL
 // SSD1306Brzo display(0x3c, D3, D5);
+// or
+// SH1106Brzo  display(0x3c, D3, D5);
 
 // Initialize the OLED display using Wire library
 SSD1306  display(0x3c, D3, D5);
+// SH1106 display(0x3c, D3, D5);
 
 OLEDDisplayUi ui ( &display );
 

--- a/examples/SSD1306DrawingDemo/SSD1306DrawingDemo.ino
+++ b/examples/SSD1306DrawingDemo/SSD1306DrawingDemo.ino
@@ -24,34 +24,42 @@
  *
  */
 
-// Include the correct display library
-// For a connection via I2C using Wire include
-#include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
-#include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
-// For a connection via I2C using brzo_i2c (must be installed) include
-// #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
-// #include "SSD1306Brzo.h"
-// For a connection via SPI include
-// #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
-// #include "SSD1306Spi.h"
+ // Include the correct display library
+ // For a connection via I2C using Wire include
+ #include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
+ #include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
+ // or #include "SH1106.h" alis for `#include "SH1106Wire.h"`
+ // For a connection via I2C using brzo_i2c (must be installed) include
+ // #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
+ // #include "SSD1306Brzo.h"
+ // #include "SH1106Brzo.h"
+ // For a connection via SPI include
+ // #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
+ // #include "SSD1306Spi.h"
+ // #include "SH1106SPi.h"
 
-// Use the corresponding display class:
+ // Use the corresponding display class:
 
-// Initialize the OLED display using SPI
-// D5 -> CLK
-// D7 -> MOSI (DOUT)
-// D0 -> RES
-// D2 -> DC
-// D8 -> CS
-// SSD1306Spi        display(D0, D2, D8);
+ // Initialize the OLED display using SPI
+ // D5 -> CLK
+ // D7 -> MOSI (DOUT)
+ // D0 -> RES
+ // D2 -> DC
+ // D8 -> CS
+ // SSD1306Spi        display(D0, D2, D8);
+ // or
+ // SH1106Spi         display(D0, D2);
 
-// Initialize the OLED display using brzo_i2c
-// D3 -> SDA
-// D4 -> SCL
-// SSD1306Brzo display(0x3c, D3, D5);
+ // Initialize the OLED display using brzo_i2c
+ // D3 -> SDA
+ // D5 -> SCL
+ // SSD1306Brzo display(0x3c, D3, D5);
+ // or
+ // SH1106Brzo  display(0x3c, D3, D5);
 
-// Initialize the OLED display using Wire library
-SSD1306  display(0x3c, D3, D5);
+ // Initialize the OLED display using Wire library
+ SSD1306  display(0x3c, D3, D5);
+ // SH1106 display(0x3c, D3, D5);
 
 // Adapted from Adafruit_SSD1306
 void drawLines() {

--- a/examples/SSD1306OTADemo/SSD1306OTADemo.ino
+++ b/examples/SSD1306OTADemo/SSD1306OTADemo.ino
@@ -39,12 +39,15 @@
 // For a connection via I2C using Wire include
 #include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
 #include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
+// or #include "SH1106.h" alis for `#include "SH1106Wire.h"`
 // For a connection via I2C using brzo_i2c (must be installed) include
 // #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Brzo.h"
+// #include "SH1106Brzo.h"
 // For a connection via SPI include
 // #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Spi.h"
+// #include "SH1106SPi.h"
 
 // Use the corresponding display class:
 
@@ -55,14 +58,19 @@
 // D2 -> DC
 // D8 -> CS
 // SSD1306Spi        display(D0, D2, D8);
+// or
+// SH1106Spi         display(D0, D2);
 
 // Initialize the OLED display using brzo_i2c
 // D3 -> SDA
-// D4 -> SCL
+// D5 -> SCL
 // SSD1306Brzo display(0x3c, D3, D5);
+// or
+// SH1106Brzo  display(0x3c, D3, D5);
 
 // Initialize the OLED display using Wire library
 SSD1306  display(0x3c, D3, D5);
+// SH1106 display(0x3c, D3, D5);
 
 
 void setup() {

--- a/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
+++ b/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
@@ -23,23 +23,22 @@
  *
  */
 
-#include <Wire.h>
-
 // Include the correct display library
 // For a connection via I2C using Wire include
 #include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
 #include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
+// or #include "SH1106.h" alis for `#include "SH1106Wire.h"`
 // For a connection via I2C using brzo_i2c (must be installed) include
 // #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Brzo.h"
+// #include "SH1106Brzo.h"
 // For a connection via SPI include
 // #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Spi.h"
+// #include "SH1106SPi.h"
 
 // Include custom images
 #include "images.h"
-
-// Use the corresponding display class:
 
 // Initialize the OLED display using SPI
 // D5 -> CLK
@@ -48,14 +47,19 @@
 // D2 -> DC
 // D8 -> CS
 // SSD1306Spi        display(D0, D2, D8);
+// or
+// SH1106Spi         display(D0, D2);
 
 // Initialize the OLED display using brzo_i2c
 // D3 -> SDA
-// D4 -> SCL
+// D5 -> SCL
 // SSD1306Brzo display(0x3c, D3, D5);
+// or
+// SH1106Brzo  display(0x3c, D3, D5);
 
 // Initialize the OLED display using Wire library
 SSD1306  display(0x3c, D3, D5);
+// SH1106 display(0x3c, D3, D5);
 
 
 #define DEMO_DURATION 3000

--- a/examples/SSD1306UiDemo/SSD1306UiDemo.ino
+++ b/examples/SSD1306UiDemo/SSD1306UiDemo.ino
@@ -24,18 +24,19 @@
  *
  */
 
-#include <Wire.h>
-
-// Include the correct display library
-// For a connection via I2C using Wire include
-#include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
-#include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
-// For a connection via I2C using brzo_i2c (must be installed) include
-// #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
-// #include "SSD1306Brzo.h"
-// For a connection via SPI include
-// #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
-// #include "SSD1306Spi.h"
+ // Include the correct display library
+ // For a connection via I2C using Wire include
+ #include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
+ #include "SSD1306.h" // alias for `#include "SSD1306Wire.h"`
+ // or #include "SH1106.h" alis for `#include "SH1106Wire.h"`
+ // For a connection via I2C using brzo_i2c (must be installed) include
+ // #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
+ // #include "SSD1306Brzo.h"
+ // #include "SH1106Brzo.h"
+ // For a connection via SPI include
+ // #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
+ // #include "SSD1306Spi.h"
+ // #include "SH1106SPi.h"
 
 // Include the UI lib
 #include "OLEDDisplayUi.h"
@@ -52,14 +53,19 @@
 // D2 -> DC
 // D8 -> CS
 // SSD1306Spi        display(D0, D2, D8);
+// or
+// SH1106Spi         display(D0, D2);
 
 // Initialize the OLED display using brzo_i2c
 // D3 -> SDA
-// D4 -> SCL
+// D5 -> SCL
 // SSD1306Brzo display(0x3c, D3, D5);
+// or
+// SH1106Brzo  display(0x3c, D3, D5);
 
 // Initialize the OLED display using Wire library
 SSD1306  display(0x3c, D3, D5);
+// SH1106 display(0x3c, D3, D5);
 
 OLEDDisplayUi ui     ( &display );
 


### PR DESCRIPTION
This PR is adding support for connecting to SH1106 displays via SPI. I also updated all examples to include all SH* drivers. 

Thanks to @squix78 for ordering one of these displays for me.