### PR TITLE
Support for custom font table look-up function

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -569,12 +569,17 @@ size_t OLEDDisplay::write(uint8_t c) {
     // Don't waste space on \r\n line endings, dropping \r
     if (c == 13) return 1;
 
+    // convert UTF-8 character to font table index
+    c = (this->fontTableLookupFunction)(c);
+    // drop unknown character
+    if (c == 0) return 1;
+
     bool maxLineNotReached = this->logBufferLine < this->logBufferMaxLines;
     bool bufferNotFull = this->logBufferFilled < this->logBufferSize;
 
     // Can we write to the buffer?
     if (bufferNotFull && maxLineNotReached) {
-      this->logBuffer[logBufferFilled] = utf8ascii(c);
+      this->logBuffer[logBufferFilled] = c;
       this->logBufferFilled++;
       // Keep track of lines written
       if (c == 10) this->logBufferLine++;
@@ -717,27 +722,6 @@ void inline OLEDDisplay::drawInternal(int16_t xMove, int16_t yMove, int16_t widt
   }
 }
 
-// Code form http://playground.arduino.cc/Main/Utf8ascii
-uint8_t OLEDDisplay::utf8ascii(byte ascii) {
-  static uint8_t LASTCHAR;
-
-  if ( ascii < 128 ) { // Standard ASCII-set 0..0x7F handling
-    LASTCHAR = 0;
-    return ascii;
-  }
-
-  uint8_t last = LASTCHAR;   // get last char
-  LASTCHAR = ascii;
-
-  switch (last) {    // conversion depnding on first UTF8-character
-    case 0xC2: return  (ascii);  break;
-    case 0xC3: return  (ascii | 0xC0);  break;
-    case 0x82: if (ascii == 0xAC) return (0x80);    // special case Euro-symbol
-  }
-
-  return  0; // otherwise: return zero, if character has to be ignored
-}
-
 // You need to free the char!
 char* OLEDDisplay::utf8ascii(String str) {
   uint16_t k = 0;
@@ -754,7 +738,7 @@ char* OLEDDisplay::utf8ascii(String str) {
   length--;
 
   for (uint16_t i=0; i < length; i++) {
-    char c = utf8ascii(s[i]);
+    char c = (this->fontTableLookupFunction)(s[i]);
     if (c!=0) {
       s[k++]=c;
     }
@@ -764,4 +748,8 @@ char* OLEDDisplay::utf8ascii(String str) {
 
   // This will leak 's' be sure to free it in the calling function.
   return s;
+}
+
+void OLEDDisplay::setFontTableLookupFunction(FontTableLookupFunction function) {
+  this->fontTableLookupFunction = function;
 }

--- a/OLEDDisplay.h
+++ b/OLEDDisplay.h
@@ -107,6 +107,7 @@ enum OLEDDISPLAY_TEXT_ALIGNMENT {
   TEXT_ALIGN_CENTER_BOTH = 3
 };
 
+typedef byte (*FontTableLookupFunction)(const byte ch);
 
 class OLEDDisplay : public Print {
   public:
@@ -183,6 +184,9 @@ class OLEDDisplay : public Print {
     // ArialMT_Plain_10, ArialMT_Plain_16, ArialMT_Plain_24
     void setFont(const char *fontData);
 
+    // Set the function that will convert utf-8 to font table index
+    void setFontTableLookupFunction(FontTableLookupFunction function);
+
     /* Display functions */
 
     // Turn the display on
@@ -253,13 +257,33 @@ class OLEDDisplay : public Print {
     void sendInitCommands();
 
     // converts utf8 characters to extended ascii
-    static char* utf8ascii(String s);
-    static byte utf8ascii(byte ascii);
+    char* utf8ascii(String s);
 
     void inline drawInternal(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const char *data, uint16_t offset, uint16_t bytesInData) __attribute__((always_inline));
 
     void drawStringInternal(int16_t xMove, int16_t yMove, char* text, uint16_t textLength, uint16_t textWidth);
 
+    // UTF-8 to font table index converter
+    // Code form http://playground.arduino.cc/Main/Utf8ascii
+    FontTableLookupFunction fontTableLookupFunction = [](const byte ch) {
+      static uint8_t LASTCHAR;
+
+      if (ch < 128) { // Standard ASCII-set 0..0x7F handling
+        LASTCHAR = 0;
+        return ch;
+      }
+
+      uint8_t last = LASTCHAR;   // get last char
+      LASTCHAR = ch;
+
+      switch (last) {    // conversion depnding on first UTF8-character
+        case 0xC2: return (uint8_t) ch;  break;
+        case 0xC3: return (uint8_t) (ch | 0xC0);  break;
+        case 0x82: if (ch == 0xAC) return (uint8_t) 0x80;    // special case Euro-symbol
+      }
+
+      return (uint8_t) 0; // otherwise: return zero, if character has to be ignored
+    };
 };
 
 #endif


### PR DESCRIPTION
This allows to create font table for any charset you want. So you can't limited by first 255 unicode chars, but you can design font table index as you want. In my case I use bellow function to convert utf-8 chars to font table index which is generated for windows-1250 encoding:

### CharsetConverter.h:
```c++
#ifndef CHARSETCONVERTER_H
#define CHARSETCONVERTER_H

#include <Arduino.h>

byte utf8win1250(const byte ch);

const char utf8_win1250_table[] = {
  0x7A,              // length of table

  // format: 0xaa, 0xbb, 0xcc 
  // 0xaabb (unicode)
  // 0xcc (win1250)
  // sorted by unicode to search with bsearch
  0x00, 0xA0, 0xA0,  // 0xA0 = NO-BREAK SPACE 
  0x00, 0xA4, 0xA4,  // 0xA4 = CURRENCY SIGN 
  0x00, 0xA6, 0xA6,  // 0xA6 = BROKEN BAR 
  0x00, 0xA7, 0xA7,  // 0xA7 = SECTION SIGN 
  0x00, 0xA8, 0xA8,  // 0xA8 = DIAERESIS 
  0x00, 0xA9, 0xA9,  // 0xA9 = COPYRIGHT SIGN 
  0x00, 0xAB, 0xAB,  // 0xAB = LEFT-POINTING DOUBLE ANGLE QUOTATION MARK 
  0x00, 0xAC, 0xAC,  // 0xAC = NOT SIGN 
  0x00, 0xAD, 0xAD,  // 0xAD = SOFT HYPHEN 
  0x00, 0xAE, 0xAE,  // 0xAE = REGISTERED SIGN 
  0x00, 0xB0, 0xB0,  // 0xB0 = DEGREE SIGN 
  0x00, 0xB1, 0xB1,  // 0xB1 = PLUS-MINUS SIGN 
  0x00, 0xB4, 0xB4,  // 0xB4 = ACUTE ACCENT 
  0x00, 0xB5, 0xB5,  // 0xB5 = MICRO SIGN 
  0x00, 0xB6, 0xB6,  // 0xB6 = PILCROW SIGN 
  0x00, 0xB7, 0xB7,  // 0xB7 = MIDDLE DOT 
  0x00, 0xB8, 0xB8,  // 0xB8 = CEDILLA 
  0x00, 0xBB, 0xBB,  // 0xBB = RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK 
  0x00, 0xC1, 0xC1,  // 0xC1 = LATIN CAPITAL LETTER A WITH ACUTE 
  0x00, 0xC2, 0xC2,  // 0xC2 = LATIN CAPITAL LETTER A WITH CIRCUMFLEX 
  0x00, 0xC4, 0xC4,  // 0xC4 = LATIN CAPITAL LETTER A WITH DIAERESIS 
  0x00, 0xC7, 0xC7,  // 0xC7 = LATIN CAPITAL LETTER C WITH CEDILLA 
  0x00, 0xC9, 0xC9,  // 0xC9 = LATIN CAPITAL LETTER E WITH ACUTE 
  0x00, 0xCB, 0xCB,  // 0xCB = LATIN CAPITAL LETTER E WITH DIAERESIS 
  0x00, 0xCD, 0xCD,  // 0xCD = LATIN CAPITAL LETTER I WITH ACUTE 
  0x00, 0xCE, 0xCE,  // 0xCE = LATIN CAPITAL LETTER I WITH CIRCUMFLEX 
  0x00, 0xD3, 0xD3,  // 0xD3 = LATIN CAPITAL LETTER O WITH ACUTE 
  0x00, 0xD4, 0xD4,  // 0xD4 = LATIN CAPITAL LETTER O WITH CIRCUMFLEX 
  0x00, 0xD6, 0xD6,  // 0xD6 = LATIN CAPITAL LETTER O WITH DIAERESIS 
  0x00, 0xD7, 0xD7,  // 0xD7 = MULTIPLICATION SIGN 
  0x00, 0xDA, 0xDA,  // 0xDA = LATIN CAPITAL LETTER U WITH ACUTE 
  0x00, 0xDC, 0xDC,  // 0xDC = LATIN CAPITAL LETTER U WITH DIAERESIS 
  0x00, 0xDD, 0xDD,  // 0xDD = LATIN CAPITAL LETTER Y WITH ACUTE 
  0x00, 0xDF, 0xDF,  // 0xDF = LATIN SMALL LETTER SHARP S 
  0x00, 0xE1, 0xE1,  // 0xE1 = LATIN SMALL LETTER A WITH ACUTE 
  0x00, 0xE2, 0xE2,  // 0xE2 = LATIN SMALL LETTER A WITH CIRCUMFLEX 
  0x00, 0xE4, 0xE4,  // 0xE4 = LATIN SMALL LETTER A WITH DIAERESIS 
  0x00, 0xE7, 0xE7,  // 0xE7 = LATIN SMALL LETTER C WITH CEDILLA 
  0x00, 0xE9, 0xE9,  // 0xE9 = LATIN SMALL LETTER E WITH ACUTE 
  0x00, 0xEB, 0xEB,  // 0xEB = LATIN SMALL LETTER E WITH DIAERESIS 
  0x00, 0xED, 0xED,  // 0xED = LATIN SMALL LETTER I WITH ACUTE 
  0x00, 0xEE, 0xEE,  // 0xEE = LATIN SMALL LETTER I WITH CIRCUMFLEX 
  0x00, 0xF3, 0xF3,  // 0xF3 = LATIN SMALL LETTER O WITH ACUTE 
  0x00, 0xF4, 0xF4,  // 0xF4 = LATIN SMALL LETTER O WITH CIRCUMFLEX 
  0x00, 0xF6, 0xF6,  // 0xF6 = LATIN SMALL LETTER O WITH DIAERESIS 
  0x00, 0xF7, 0xF7,  // 0xF7 = DIVISION SIGN 
  0x00, 0xFA, 0xFA,  // 0xFA = LATIN SMALL LETTER U WITH ACUTE 
  0x00, 0xFC, 0xFC,  // 0xFC = LATIN SMALL LETTER U WITH DIAERESIS 
  0x00, 0xFD, 0xFD,  // 0xFD = LATIN SMALL LETTER Y WITH ACUTE 
  0x01, 0x02, 0xC3,  // 0xC3 = LATIN CAPITAL LETTER A WITH BREVE 
  0x01, 0x03, 0xE3,  // 0xE3 = LATIN SMALL LETTER A WITH BREVE 
  0x01, 0x04, 0xA5,  // 0xA5 = LATIN CAPITAL LETTER A WITH OGONEK 
  0x01, 0x05, 0xB9,  // 0xB9 = LATIN SMALL LETTER A WITH OGONEK 
  0x01, 0x06, 0xC6,  // 0xC6 = LATIN CAPITAL LETTER C WITH ACUTE 
  0x01, 0x07, 0xE6,  // 0xE6 = LATIN SMALL LETTER C WITH ACUTE 
  0x01, 0x0C, 0xC8,  // 0xC8 = LATIN CAPITAL LETTER C WITH CARON 
  0x01, 0x0D, 0xE8,  // 0xE8 = LATIN SMALL LETTER C WITH CARON 
  0x01, 0x0E, 0xCF,  // 0xCF = LATIN CAPITAL LETTER D WITH CARON 
  0x01, 0x0F, 0xEF,  // 0xEF = LATIN SMALL LETTER D WITH CARON 
  0x01, 0x10, 0xD0,  // 0xD0 = LATIN CAPITAL LETTER D WITH STROKE 
  0x01, 0x11, 0xF0,  // 0xF0 = LATIN SMALL LETTER D WITH STROKE 
  0x01, 0x18, 0xCA,  // 0xCA = LATIN CAPITAL LETTER E WITH OGONEK 
  0x01, 0x19, 0xEA,  // 0xEA = LATIN SMALL LETTER E WITH OGONEK 
  0x01, 0x1A, 0xCC,  // 0xCC = LATIN CAPITAL LETTER E WITH CARON 
  0x01, 0x1B, 0xEC,  // 0xEC = LATIN SMALL LETTER E WITH CARON 
  0x01, 0x39, 0xC5,  // 0xC5 = LATIN CAPITAL LETTER L WITH ACUTE 
  0x01, 0x3A, 0xE5,  // 0xE5 = LATIN SMALL LETTER L WITH ACUTE 
  0x01, 0x3D, 0xBC,  // 0xBC = LATIN CAPITAL LETTER L WITH CARON 
  0x01, 0x3E, 0xBE,  // 0xBE = LATIN SMALL LETTER L WITH CARON 
  0x01, 0x41, 0xA3,  // 0xA3 = LATIN CAPITAL LETTER L WITH STROKE 
  0x01, 0x42, 0xB3,  // 0xB3 = LATIN SMALL LETTER L WITH STROKE 
  0x01, 0x43, 0xD1,  // 0xD1 = LATIN CAPITAL LETTER N WITH ACUTE 
  0x01, 0x44, 0xF1,  // 0xF1 = LATIN SMALL LETTER N WITH ACUTE 
  0x01, 0x47, 0xD2,  // 0xD2 = LATIN CAPITAL LETTER N WITH CARON 
  0x01, 0x48, 0xF2,  // 0xF2 = LATIN SMALL LETTER N WITH CARON 
  0x01, 0x50, 0xD5,  // 0xD5 = LATIN CAPITAL LETTER O WITH DOUBLE ACUTE 
  0x01, 0x51, 0xF5,  // 0xF5 = LATIN SMALL LETTER O WITH DOUBLE ACUTE 
  0x01, 0x54, 0xC0,  // 0xC0 = LATIN CAPITAL LETTER R WITH ACUTE 
  0x01, 0x55, 0xE0,  // 0xE0 = LATIN SMALL LETTER R WITH ACUTE 
  0x01, 0x58, 0xD8,  // 0xD8 = LATIN CAPITAL LETTER R WITH CARON 
  0x01, 0x59, 0xF8,  // 0xF8 = LATIN SMALL LETTER R WITH CARON 
  0x01, 0x5A, 0x8C,  // 0x8C = LATIN CAPITAL LETTER S WITH ACUTE 
  0x01, 0x5B, 0x9C,  // 0x9C = LATIN SMALL LETTER S WITH ACUTE 
  0x01, 0x5E, 0xAA,  // 0xAA = LATIN CAPITAL LETTER S WITH CEDILLA 
  0x01, 0x5F, 0xBA,  // 0xBA = LATIN SMALL LETTER S WITH CEDILLA 
  0x01, 0x60, 0x8A,  // 0x8A = LATIN CAPITAL LETTER S WITH CARON 
  0x01, 0x61, 0x9A,  // 0x9A = LATIN SMALL LETTER S WITH CARON 
  0x01, 0x62, 0xDE,  // 0xDE = LATIN CAPITAL LETTER T WITH CEDILLA 
  0x01, 0x63, 0xFE,  // 0xFE = LATIN SMALL LETTER T WITH CEDILLA 
  0x01, 0x64, 0x8D,  // 0x8D = LATIN CAPITAL LETTER T WITH CARON 
  0x01, 0x65, 0x9D,  // 0x9D = LATIN SMALL LETTER T WITH CARON 
  0x01, 0x6E, 0xD9,  // 0xD9 = LATIN CAPITAL LETTER U WITH RING ABOVE 
  0x01, 0x6F, 0xF9,  // 0xF9 = LATIN SMALL LETTER U WITH RING ABOVE 
  0x01, 0x70, 0xDB,  // 0xDB = LATIN CAPITAL LETTER U WITH DOUBLE ACUTE 
  0x01, 0x71, 0xFB,  // 0xFB = LATIN SMALL LETTER U WITH DOUBLE ACUTE 
  0x01, 0x79, 0x8F,  // 0x8F = LATIN CAPITAL LETTER Z WITH ACUTE 
  0x01, 0x7A, 0x9F,  // 0x9F = LATIN SMALL LETTER Z WITH ACUTE 
  0x01, 0x7B, 0xAF,  // 0xAF = LATIN CAPITAL LETTER Z WITH DOT ABOVE 
  0x01, 0x7C, 0xBF,  // 0xBF = LATIN SMALL LETTER Z WITH DOT ABOVE 
  0x01, 0x7D, 0x8E,  // 0x8E = LATIN CAPITAL LETTER Z WITH CARON 
  0x01, 0x7E, 0x9E,  // 0x9E = LATIN SMALL LETTER Z WITH CARON 
  0x02, 0xC7, 0xA1,  // 0xA1 = CARON 
  0x02, 0xD8, 0xA2,  // 0xA2 = BREVE 
  0x02, 0xD9, 0xFF,  // 0xFF = DOT ABOVE 
  0x02, 0xDB, 0xB2,  // 0xB2 = OGONEK 
  0x02, 0xDD, 0xBD,  // 0xBD = DOUBLE ACUTE ACCENT 
  0x20, 0x13, 0x96,  // 0x96 = EN DASH 
  0x20, 0x14, 0x97,  // 0x97 = EM DASH 
  0x20, 0x18, 0x91,  // 0x91 = LEFT SINGLE QUOTATION MARK 
  0x20, 0x19, 0x92,  // 0x92 = RIGHT SINGLE QUOTATION MARK 
  0x20, 0x1A, 0x82,  // 0x82 = SINGLE LOW-9 QUOTATION MARK 
  0x20, 0x1C, 0x93,  // 0x93 = LEFT DOUBLE QUOTATION MARK 
  0x20, 0x1D, 0x94,  // 0x94 = RIGHT DOUBLE QUOTATION MARK 
  0x20, 0x1E, 0x84,  // 0x84 = DOUBLE LOW-9 QUOTATION MARK 
  0x20, 0x20, 0x86,  // 0x86 = DAGGER 
  0x20, 0x21, 0x87,  // 0x87 = DOUBLE DAGGER 
  0x20, 0x22, 0x95,  // 0x95 = BULLET 
  0x20, 0x26, 0x85,  // 0x85 = HORIZONTAL ELLIPSIS 
  0x20, 0x30, 0x89,  // 0x89 = PER MILLE SIGN 
  0x20, 0x39, 0x8B,  // 0x8B = SINGLE LEFT-POINTING ANGLE QUOTATION MARK 
  0x20, 0x3A, 0x9B,  // 0x9B = SINGLE RIGHT-POINTING ANGLE QUOTATION MARK 
  0x20, 0xAC, 0x80,  // 0x80 = EURO SIGN 
  0x21, 0x22, 0x99   // 0x99 = TRADE MARK SIGN 
}; 

#endif
```

### CharsetConverter.cpp:
```c++
#include <Arduino.h>
#include "CharsetConverter.h"

// In ESP8266 Arduino core v2.3.0 missing bsearch: https://github.com/esp8266/Arduino/issues/2314
// Part of GNU C Library
void * gnu_c_bsearch (const void *key, const void *base, size_t nmemb, size_t size, int (*compar) (const void *, const void *)) {
  size_t l, u, idx;
  const void *p;
  int comparison;

  l = 0;
  u = nmemb;
  while (l < u) {
    idx = (l + u) / 2;

    p = (void *) (((const char *) base) + (idx * size));
    comparison = (*compar) (key, p);
    if (comparison < 0)
      u = idx;
    else if (comparison > 0)
      l = idx + 1;
    else
      return (void *) p;
  }

  return NULL;
}

// compare function for bsearch
int charset_table_cmp(const void* p_key, const void* p_item) {
  const uint16_t key = *(uint16_t *) p_key;
  const uint16_t item = (*((char *) p_item)) << 8 | *(((char *) p_item) + 1);
    
  if (key < item) return -1;
  else if (key == item) return 0;
  else return 1;
}

// convert utf-8 character to windows-1250
// if utf-8 char continue with next byte, returns 0, otherwise windows-1250 char
// for unconvertable char returns 0
byte utf8win1250(const byte ch) {
  static uint16_t uChar;
  static uint8_t len;
  char *found;

  if ((ch & 0x80) == 0x00) {
    uChar = len = 0;
    return ch;
  } else if ((ch & 0xE0) == 0xC0) {
    uChar = ch & 0x1F; len = 1;
    return 0;
  } else if ((ch & 0xF0) == 0xE0) {
    uChar = ch & 0x0F; len = 2;
    return 0;
  } else if ((ch & 0xF8) == 0xF0) {
    uChar = ch & 0x07; len = 3;
    return 0;
  } else if ((ch & 0xC0) == 0x80 && len > 0) {
    uChar = (uChar << 6) | (ch & 0x7F); len--;
    if (len > 0)
      return 0;
  } else {
    uChar = len = 0;
    return 0;
  }

  found = (char*) gnu_c_bsearch(&uChar, utf8_win1250_table + 1, utf8_win1250_table[0], 3 * sizeof(char), charset_table_cmp);

  if (found != NULL) {
    uChar = len = 0;
    return *(found + 2); // return win1250 char at 3rd position;
  }

  return 0;
}
```

Usage:
```c++
#include "CharsetConverter.h"

// Initialize the oled display
SSD1306Wire     display(I2C_DISPLAY_ADDRESS, SDA_PIN, SDC_PIN);
OLEDDisplayUi   ui( &display );

void setup() {
  // initialize dispaly
  display.init();
  display.clear();
  display.setContrast(CONTRAST);
  display.display();

  display.setFont(Arial_Plain_10); // font generated with table index of windows-1250
  display.setFontTableLookupFunction(&utf8win1250);
}
```