### PR TITLE
Closer to middle vertical align

### DIFF
--- a/OLEDDisplayUi.cpp
+++ b/OLEDDisplayUi.cpp
@@ -372,11 +372,11 @@ void OLEDDisplayUi::drawIndicator() {
           break;
         case RIGHT:
           x = 120 + (8 * indicatorFadeProgress);
-          y = 32 - frameStartPos + 12 * i;
+          y = 32 - frameStartPos + 2 + 12 * i;
           break;
         case LEFT:
           x = 0 - (8 * indicatorFadeProgress);
-          y = 32 - frameStartPos + 12 * i;
+          y = 32 - frameStartPos + 2 + 12 * i;
           break;
       }
 


### PR DESCRIPTION
Due to the 4px spacing, the indicators are a bit offset when adding them to LEFT or RIGHT sides of screen

(at least i hope i got it right)
