### PR TITLE
Make OLEDDisplay.display() an abstract function

### DIFF
--- a/OLEDDisplay.h
+++ b/OLEDDisplay.h
@@ -207,7 +207,7 @@ class OLEDDisplay : public Print {
     void flipScreenVertically();
 
     // Write the buffer to the display memory
-    virtual void display(void);
+    virtual void display(void) = 0;
 
     // Clear the local pixel buffer
     void clear(void);


### PR DESCRIPTION
Without the `= 0` declaration, compiling with RTTI enabled fails.
See http://stackoverflow.com/a/307427/1880101 for an explanation.