### PR TITLE
Movement direction

### DIFF
--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -339,14 +339,19 @@ void OLEDDisplayUi::drawFrame(){
 
        bool drawnCurrentFrame;
 
-
        // Probe each frameFunction for the indicator drawn state
+       FrameState oldFrameState=this->state.frameState;
+
        this->enableIndicator();
+       this->state.frameState=IN_TRANSITION_OUT;
        (this->frameFunctions[this->state.currentFrame])(this->display, &this->state, x, y);
        drawnCurrentFrame = this->state.isIndicatorDrawn;
 
        this->enableIndicator();
+       this->state.frameState=IN_TRANSITION_IN;
        (this->frameFunctions[this->getNextFrameNumber()])(this->display, &this->state, x1, y1);
+
+       this->state.frameState=oldFrameState;
 
        // Build up the indicatorDrawState
        if (drawnCurrentFrame && !this->state.isIndicatorDrawn) {

--- a/src/OLEDDisplayUi.h
+++ b/src/OLEDDisplayUi.h
@@ -69,6 +69,8 @@ enum IndicatorDirection {
 
 enum FrameState {
   IN_TRANSITION,
+  IN_TRANSITION_IN,
+  IN_TRANSITION_OUT,
   FIXED
 };
 


### PR DESCRIPTION
As a POC for [356](https://github.com/ThingPulse/esp8266-oled-ssd1306/issues/356).

Problem:

I need to draw overlay (actually a set of indicators) on some particular frames only. Let they be "Fo". Other frames should not have this overlay at all. Assume, they are "F"
I want this overlay to stay unmovable during "Fo -> Fo" frames transitions. But during Fo -> F transition, I want this overlay to be moved among Fo frame it currently belongs to. And vice versa, during F -> Fo transition, I want this overlay to move into the viewport together with Fo frame it belongs to. 

Proposed solution:
To implement this, I can add a code to every frame drawing function, that would draw this overlay. But in order to understand the overlay's offset (i. e. do I need to move the overlay together with the frame or it shall be fixed), I have to understand, is my current frame "slides in" or "out" the viewport. This is what this PR is intended to solve.