### PR TITLE
Bug Fix: Remove sendCommand(NORMALDISPLAY) from setContrast()

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,14 @@ void normalDisplay(void);
 // Set display contrast
 // really low brightness & contrast: contrast = 10, precharge = 5, comdetect = 0
 // normal brightness & contrast:  contrast = 100
-void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64);
+// forceNormal = true - forces normal display mode (default)
+//              false - preserves current display mode (normal/inverted)
+void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64, bool forceNormal = true);
 
-// Convenience method to access
-void setBrightness(uint8_t);
+// Convenience method to access setContrast with simplified parameters
+// forceNormal = true - forces normal display mode (default)
+//              false - preserves current display mode (normal/inverted)
+void setBrightness(uint8_t, bool forceNormal = true);
 
 // Turn the display upside down
 void flipScreenVertically();

--- a/README.md
+++ b/README.md
@@ -169,14 +169,10 @@ void normalDisplay(void);
 // Set display contrast
 // really low brightness & contrast: contrast = 10, precharge = 5, comdetect = 0
 // normal brightness & contrast:  contrast = 100
-// forceNormal = true - forces normal display mode (default)
-//              false - preserves current display mode (normal/inverted)
-void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64, bool forceNormal = true);
+void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64);
 
-// Convenience method to access setContrast with simplified parameters
-// forceNormal = true - forces normal display mode (default)
-//              false - preserves current display mode (normal/inverted)
-void setBrightness(uint8_t, bool forceNormal = true);
+// Convenience method to access setContrast with only brightness parameter
+void setBrightness(uint8_t);
 
 // Turn the display upside down
 void flipScreenVertically();

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -776,7 +776,7 @@ void OLEDDisplay::normalDisplay(void) {
   sendCommand(NORMALDISPLAY);
 }
 
-void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comdetect, bool forceNormal) {
+void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comdetect) {
   sendCommand(SETPRECHARGE); //0xD9
   sendCommand(precharge); //0xF1 default, to lower the contrast, put 1-1F
   sendCommand(SETCONTRAST);
@@ -784,15 +784,10 @@ void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comde
   sendCommand(SETVCOMDETECT); //0xDB, (additionally needed to lower the contrast)
   sendCommand(comdetect);	//0x40 default, to lower the contrast, put 0
   sendCommand(DISPLAYALLON_RESUME);
-  // Only force normal display if requested (default: true for backwards compatibility)
-  // Set to false to preserve invertDisplay() state
-  if (forceNormal) {
-    sendCommand(NORMALDISPLAY);
-  }
   sendCommand(DISPLAYON);
 }
 
-void OLEDDisplay::setBrightness(uint8_t brightness, bool forceNormal) {
+void OLEDDisplay::setBrightness(uint8_t brightness) {
   uint8_t contrast = brightness;
   if (brightness < 128) {
     // Magic values to get a smooth/ step-free transition
@@ -807,7 +802,7 @@ void OLEDDisplay::setBrightness(uint8_t brightness, bool forceNormal) {
   }
   uint8_t comdetect = brightness / 8;
 
-  setContrast(contrast, precharge, comdetect, forceNormal);
+  setContrast(contrast, precharge, comdetect);
 }
 
 void OLEDDisplay::resetOrientation() {

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -776,7 +776,7 @@ void OLEDDisplay::normalDisplay(void) {
   sendCommand(NORMALDISPLAY);
 }
 
-void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comdetect) {
+void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comdetect, bool forceNormal) {
   sendCommand(SETPRECHARGE); //0xD9
   sendCommand(precharge); //0xF1 default, to lower the contrast, put 1-1F
   sendCommand(SETCONTRAST);
@@ -784,11 +784,15 @@ void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comde
   sendCommand(SETVCOMDETECT); //0xDB, (additionally needed to lower the contrast)
   sendCommand(comdetect);	//0x40 default, to lower the contrast, put 0
   sendCommand(DISPLAYALLON_RESUME);
-  sendCommand(NORMALDISPLAY);
+  // Only force normal display if requested (default: true for backwards compatibility)
+  // Set to false to preserve invertDisplay() state
+  if (forceNormal) {
+    sendCommand(NORMALDISPLAY);
+  } 
   sendCommand(DISPLAYON);
 }
 
-void OLEDDisplay::setBrightness(uint8_t brightness) {
+void OLEDDisplay::setBrightness(uint8_t brightness, bool forceNormal) {
   uint8_t contrast = brightness;
   if (brightness < 128) {
     // Magic values to get a smooth/ step-free transition
@@ -803,7 +807,7 @@ void OLEDDisplay::setBrightness(uint8_t brightness) {
   }
   uint8_t comdetect = brightness / 8;
 
-  setContrast(contrast, precharge, comdetect);
+  setContrast(contrast, precharge, comdetect, forceNormal);
 }
 
 void OLEDDisplay::resetOrientation() {

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -788,7 +788,7 @@ void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comde
   // Set to false to preserve invertDisplay() state
   if (forceNormal) {
     sendCommand(NORMALDISPLAY);
-  } 
+  }
   sendCommand(DISPLAYON);
 }
 

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -294,10 +294,16 @@ class OLEDDisplay : public Stream {
     // Set display contrast
     // really low brightness & contrast: contrast = 10, precharge = 5, comdetect = 0
     // normal brightness & contrast:  contrast = 100
-    void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64);
+    // forceNormal = true - forces normal display mode (white on black),
+    //                      overriding any previous invertDisplay() call (default)
+    //              false - preserves current display mode (normal/inverted)
+    void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64, bool forceNormal = true);
 
-    // Convenience method to access
-    void setBrightness(uint8_t);
+    // Convenience method to access setContrast with simplified parameters
+    // forceNormal = true - forces normal display mode (white on black),
+    //                      overriding any previous invertDisplay() call (default)
+    //              false - preserves current display mode (normal/inverted)
+    void setBrightness(uint8_t, bool forceNormal = true);
 
     // Reset display rotation or mirroring
     void resetOrientation();

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -294,16 +294,10 @@ class OLEDDisplay : public Stream {
     // Set display contrast
     // really low brightness & contrast: contrast = 10, precharge = 5, comdetect = 0
     // normal brightness & contrast:  contrast = 100
-    // forceNormal = true - forces normal display mode (white on black),
-    //                      overriding any previous invertDisplay() call (default)
-    //              false - preserves current display mode (normal/inverted)
-    void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64, bool forceNormal = true);
+    void setContrast(uint8_t contrast, uint8_t precharge = 241, uint8_t comdetect = 64);
 
-    // Convenience method to access setContrast with simplified parameters
-    // forceNormal = true - forces normal display mode (white on black),
-    //                      overriding any previous invertDisplay() call (default)
-    //              false - preserves current display mode (normal/inverted)
-    void setBrightness(uint8_t, bool forceNormal = true);
+    // Convenience method to access setContrast with only brightness parameter
+    void setBrightness(uint8_t);
 
     // Reset display rotation or mirroring
     void resetOrientation();


### PR DESCRIPTION
This pull request updates the `setContrast` method to fix an unwanted call to reset the display to `NORMALDISPLAY` mode rather than just sending the contrast related commands.

Removes `sendCommand(NORMALDISPLAY)`:

```cpp
void OLEDDisplay::setContrast(uint8_t contrast, uint8_t precharge, uint8_t comdetect) {
  sendCommand(SETPRECHARGE); //0xD9
  sendCommand(precharge); //0xF1 default, to lower the contrast, put 1-1F
  sendCommand(SETCONTRAST);
  sendCommand(contrast); // 0-255
  sendCommand(SETVCOMDETECT); //0xDB, (additionally needed to lower the contrast)
  sendCommand(comdetect);	//0x40 default, to lower the contrast, put 0
  sendCommand(DISPLAYALLON_RESUME);
// sendCommand(NORMALDISPLAY);
  sendCommand(DISPLAYON);
}

```

Minor:
  * Updated comments in both `README.md` and `src/OLEDDisplay.h` to clarify that `setBrightness` is a convenience method for `setContrast` with only the brightness parameter. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L174-R174) [[2]](diffhunk://#diff-489ae690477d48294513cf5ef6f339c2164f855bef04394590a64eaa5c005b7cL299-R299)


Closes #426